### PR TITLE
Setting capacity when initializing a Queue will error out unless RedisQueue has been initialized

### DIFF
--- a/lib/coordinator/queue.rb
+++ b/lib/coordinator/queue.rb
@@ -4,10 +4,11 @@ module Coordinator
 
     def initialize(skill, capacity=nil, &block)
       @skill = skill
-      self.capacity = capacity if capacity
       @custom_block = block if block_given?
 
       super(skill)
+
+      self.capacity = capacity if capacity
     end
 
     def next_task(skills)

--- a/test/unit/queue_test.rb
+++ b/test/unit/queue_test.rb
@@ -6,6 +6,13 @@ describe "Coordinator::Queue" do
     Redis.current.flushall
   end
 
+  describe 'initialize' do
+    it 'can capacity when option argument is passed in' do
+      @queue = Coordinator::Queue.new("high", 500)
+      assert_equal 500, @queue.capacity
+    end
+  end
+
   describe 'next_task' do
     it 'returns task when eligible' do
       @queue.push(1)


### PR DESCRIPTION
@tylermercier 

To fix this error when trying to pass capacity when initializing `Coordinator::Queue`:

```
NoMethodError: undefined method `set' for nil:NilClass
    /home/vagrant/src/coordinator/lib/coordinator/redis_queue.rb:48:in `capacity='
    /home/vagrant/src/coordinator/lib/coordinator/queue.rb:7:in `initialize'
    /home/vagrant/src/coordinator/test/unit/queue_test.rb:11:in `new'
    /home/vagrant/src/coordinator/test/unit/queue_test.rb:11:in `block (3 levels) in <top (required)>'
```

Happens because setting capacity works with Redis, but needs this line to be run before doing so:
https://github.com/tylermercier/coordinator/blob/master/lib/coordinator/redis_queue.rb#L9
