### PR TITLE
Add Base#info_all method to iterate through all available queues...

### DIFF
--- a/lib/coordinator/base.rb
+++ b/lib/coordinator/base.rb
@@ -36,6 +36,13 @@ module Coordinator
       queue_for_skill(skill).details
     end
 
+    def info_all
+      @queues.inject({}) do |hash, queue|
+        hash[queue.skill] = info(queue.skill)
+        hash
+      end
+    end
+
     def position(skill, task)
       index = queue_for_skill(skill).items.index(task)
       index ? index + 1 : -1

--- a/lib/coordinator/version.rb
+++ b/lib/coordinator/version.rb
@@ -1,3 +1,3 @@
 module Coordinator
-  VERSION = "0.0.12"
+  VERSION = "0.0.13"
 end

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -56,6 +56,20 @@ describe 'Coordinator::Base' do
 
   describe 'info' do
     it 'returns queue specific details' do
+      @coordinator.add_task("high", "high task")
+      @coordinator.add_task("medium", "medium task 1")
+      @coordinator.add_task("medium", "medium task 2")
+      @coordinator.add_task("low", "medium task 2")
+      info = @coordinator.info_all
+
+      assert_equal @coordinator.info("high"), info["high"]
+      assert_equal @coordinator.info("medium"), info["medium"]
+      assert_equal @coordinator.info("low"), info["low"]
+    end
+  end
+
+  describe 'info_all' do
+    it 'returns a hash with details for each queue' do
       @coordinator.add_task("high", "new task")
       info = @coordinator.info("high")
       assert_equal "high", info["name"]

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -56,6 +56,18 @@ describe 'Coordinator::Base' do
 
   describe 'info' do
     it 'returns queue specific details' do
+      @coordinator.add_task("high", "new task")
+      info = @coordinator.info("high")
+      assert_equal "high", info["name"]
+      assert_equal nil, info["full"]
+      assert_equal nil, info["capacity"]
+      assert_equal 1, info["count"]
+      assert_equal ["new task"], info["items"]
+    end
+  end
+
+  describe 'info_all' do
+    it 'returns a hash with details for each queue' do
       @coordinator.add_task("high", "high task")
       @coordinator.add_task("medium", "medium task 1")
       @coordinator.add_task("medium", "medium task 2")
@@ -65,18 +77,6 @@ describe 'Coordinator::Base' do
       assert_equal @coordinator.info("high"), info["high"]
       assert_equal @coordinator.info("medium"), info["medium"]
       assert_equal @coordinator.info("low"), info["low"]
-    end
-  end
-
-  describe 'info_all' do
-    it 'returns a hash with details for each queue' do
-      @coordinator.add_task("high", "new task")
-      info = @coordinator.info("high")
-      assert_equal "high", info["name"]
-      assert_equal nil, info["full"]
-      assert_equal nil, info["capacity"]
-      assert_equal 1, info["count"]
-      assert_equal ["new task"], info["items"]
     end
   end
 


### PR DESCRIPTION
... and get their details

Will be used in [this PR](https://github.com/Shopify/q2/pull/292) to get the queue sizes and wait times for each queue.

In phones we'll have to loop through all tasks for each queue, get the oldest timestamp to calculate the wait time for that queue (with call transfers the oldest task might not be at the top).

@tylermercier @odorcicd 
