### PR TITLE
fix comparison between serialized items and data

### DIFF
--- a/lib/coordinator/redis_queue.rb
+++ b/lib/coordinator/redis_queue.rb
@@ -12,12 +12,12 @@ module Coordinator
     def push(item)
       return false if full?
       data = serialize(item)
-      @redis.rpush(@queue_name, data) unless items.include?(data)
+      @redis.rpush(@queue_name, data) unless serialized_items.include?(data)
     end
 
     def left_push(item)
       data = serialize(item)
-      @redis.lpush(@queue_name, data) unless items.include?(data)
+      @redis.lpush(@queue_name, data) unless serialized_items.include?(data)
     end
 
     def pop
@@ -49,7 +49,7 @@ module Coordinator
     end
 
     def items
-      @redis.lrange(@queue_name, 0, length).map { |i| deserialize(i) }
+      serialized_items.map { |i| deserialize(i) }
     end
 
     def full?
@@ -57,6 +57,10 @@ module Coordinator
     end
 
     private
+
+    def serialized_items
+      @redis.lrange(@queue_name, 0, length)
+    end
 
     def serialize(item)
       item.is_a?(String) ? item : item.to_json

--- a/lib/coordinator/version.rb
+++ b/lib/coordinator/version.rb
@@ -1,3 +1,3 @@
 module Coordinator
-  VERSION = "0.0.13"
+  VERSION = "0.0.14"
 end

--- a/test/unit/redis_queue_test.rb
+++ b/test/unit/redis_queue_test.rb
@@ -13,6 +13,17 @@ describe 'Coordinator::RedisQueue' do
       assert_equal 2, @queue.length
     end
 
+    it 'adds same hash to queue only once' do
+      el = {
+        'id' => 10,
+        'subject' => 'testing'
+      }
+
+      @queue.push(el)
+      @queue.push(el)
+      assert_equal 1, @queue.length
+    end
+
     it 'adds the same item only once' do
       @queue.push("a")
       @queue.push("a")


### PR DESCRIPTION
Coordinator could add push multiple copies of the same object because the comparison was between serialized data vs unserialized list of existing items in the queue.

This fixes that, by comparing serialized data against list of serialized items.

Need this to use in a tasker-email PR

@tylermercier 
